### PR TITLE
Bug Fixed

### DIFF
--- a/ibm-xforce-threat-intel-feed/info.json
+++ b/ibm-xforce-threat-intel-feed/info.json
@@ -113,8 +113,9 @@
         "visible": true,
         "type": "text",
         "name": "server_url",
-        "value": "https://api.xforce.ibmcloud.com",
-        "description": "Review the server URL of the IBM X-Force Threat Intelligence Feed server to which you will connect and retrieve data."
+        "placeholder": "For Public X-Force Exchange API use https://api.xforce.ibmcloud.com",
+        "tooltip": "Review the server URL of the IBM X-Force Threat Intelligence Feed server to which you will connect and retrieve data. Note: For Public X-Force Exchange API use server URL: https://api.xforce.ibmcloud.com",
+        "description": "Review the server URL of the IBM X-Force Threat Intelligence Feed server to which you will connect and retrieve data. Note: For Public X-Force Exchange API use server URL: https://api.xforce.ibmcloud.com"
       },
       {
         "title": "API Key",


### PR DESCRIPTION
#### PMDB: 37294

#### Mantis:

- 1183047: [TIM] Update default URL for IBM X-Force Threat Intelligence Feed to https://xf-taxiiserver.intsum.ibm.com/

#### Descriptions:

- Removed default value for server URL, added in placeholder and tooltip.
